### PR TITLE
Fix: create parent directories for output files

### DIFF
--- a/pkg/webhook_tester/default_webhook_tester.go
+++ b/pkg/webhook_tester/default_webhook_tester.go
@@ -200,7 +200,7 @@ func (wt *DefaultWebhookTester) PostProcess() error {
 	for _, output := range wt.config.Outputs {
 		switch output.Type {
 		case "text":
-			w, err := os.Create(output.Path)
+			w, err := createFileWithParentDirs(output.Path)
 			defer w.Close()
 			if err != nil {
 				return err

--- a/pkg/webhook_tester/file.go
+++ b/pkg/webhook_tester/file.go
@@ -1,0 +1,9 @@
+package webhook_tester
+
+import "os"
+
+// createFileWithParentDirs creates a file at the given path.
+// If the parent directories do not exist, they will be created.
+func createFileWithParentDirs(path string) (*os.File, error) {
+	return os.Create(path)
+}

--- a/pkg/webhook_tester/file.go
+++ b/pkg/webhook_tester/file.go
@@ -1,9 +1,15 @@
 package webhook_tester
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // createFileWithParentDirs creates a file at the given path.
 // If the parent directories do not exist, they will be created.
 func createFileWithParentDirs(path string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, err
+	}
 	return os.Create(path)
 }

--- a/pkg/webhook_tester/file_test.go
+++ b/pkg/webhook_tester/file_test.go
@@ -1,0 +1,32 @@
+package webhook_tester
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateFileWithParentDirs_CreatesParentDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Path with non-existent parent directories
+	outputPath := filepath.Join(tmpDir, "reports", "subdir", "output.txt")
+
+	// Verify parent directory doesn't exist
+	parentDir := filepath.Dir(outputPath)
+	if _, err := os.Stat(parentDir); !os.IsNotExist(err) {
+		t.Fatalf("Expected directory %s to not exist", parentDir)
+	}
+
+	// Should create parent dirs and file
+	f, err := createFileWithParentDirs(outputPath)
+	if err != nil {
+		t.Fatalf("createFileWithParentDirs failed: %v", err)
+	}
+	defer f.Close()
+
+	// Verify file was created
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Errorf("Expected file %s to be created", outputPath)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `createFileWithParentDirs` helper that creates parent directories before creating a file
- Update output file creation to use this helper
- Add test to verify directory creation behavior

Closes #8

## Test plan
- [x] Added unit test for `createFileWithParentDirs`
- [ ] Manual test: run with config that specifies non-existent output directory